### PR TITLE
Fix tests and enable deterministic versioning in Docker builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,5 +29,10 @@ jobs:
         with:
           context: .
           push: true
+          # github.ref_name is the tag as-is (e.g. "v1.2.3").
+          # SETUPTOOLS_SCM_PRETEND_VERSION strips the leading "v" internally,
+          # so no separate normalisation step is needed.
+          build-args: |
+            VERSION=${{ github.ref_name }}
           tags: |
             ghcr.io/ignytex-labs/kivoll_worker:${{ github.ref_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,9 +29,6 @@ jobs:
         with:
           context: .
           push: true
-          # github.ref_name is the tag as-is (e.g. "v1.2.3").
-          # SETUPTOOLS_SCM_PRETEND_VERSION strips the leading "v" internally,
-          # so no separate normalisation step is needed.
           build-args: |
             VERSION=${{ github.ref_name }}
           tags: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history so setuptools-scm can infer the version
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,15 @@ RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv,sharing=locked \
 # ---- Stage 2: Build the distributable wheel ----
 FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
 
-# VERSION is a build arg; SETUPTOOLS_SCM_PRETEND_VERSION lets setuptools-scm work without git.
+# VERSION is a build arg
 ARG VERSION
+# SETUPTOOLS_SCM_PRETEND_VERSION lets setuptools-scm work without git.
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
 WORKDIR /app
 
 # uv.lock is intentionally omitted: `uv build` calls the build backend directly
-COPY pyproject.toml README.md LICENSE ./
+COPY pyproject.toml README.md healthcheck.sh LICENSE ./
 COPY src/ ./src/
 
 RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv,sharing=locked \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,15 @@ RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv,sharing=locked \
 # ---- Stage 2: Build the distributable wheel ----
 FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
 
-# git is required by setuptools-scm for SCM-based version detection
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends git \
-    && rm -rf /var/lib/apt/lists/*
+# VERSION is a build arg; SETUPTOOLS_SCM_PRETEND_VERSION lets setuptools-scm work without git.
+ARG VERSION
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
 WORKDIR /app
 
-COPY . .
+# uv.lock is intentionally omitted: `uv build` calls the build backend directly
+COPY pyproject.toml README.md LICENSE ./
+COPY src/ ./src/
 
 RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv,sharing=locked \
     uv build --wheel

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,11 @@ RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv,sharing=locked \
 # ---- Stage 2: Build the distributable wheel ----
 FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
 
-# VERSION is a build arg
+# VERSION is a required build arg
 ARG VERSION
+RUN test -n "${VERSION}" || \
+    { echo "ERROR: VERSION build arg is required. Pass --build-arg VERSION=x.y.z" \
+    >&2; exit 1; }
 # SETUPTOOLS_SCM_PRETEND_VERSION lets setuptools-scm work without git.
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -12,9 +12,14 @@ from testcontainers.core.container import DockerContainer
 from testcontainers.core.network import Network
 
 from conftest import _build_container, _wait_for_db_ready
-from kivoll_worker import __version__
 
 DATABASE_IMG = "ghcr.io/ignytex-labs/kivoll_db:0.1.0"
+
+# Fixed sentinel version used when building the worker image for tests.
+# Using a constant keeps tests hermetic (independent of the local git state)
+# and validates that the VERSION build-arg is correctly propagated through
+# SETUPTOOLS_SCM_PRETEND_VERSION all the way to the installed package.
+TEST_VERSION = "0.0.0"
 
 
 @dataclass(frozen=True)
@@ -90,7 +95,15 @@ def built_db_image(
 ) -> Generator[BuiltImage, Any, None]:
     # Run docker build and record output; don't fail the fixture immediately.
     result = subprocess.run(
-        ["docker", "build", "-t", db_image_tag, str(BUILD_CONTEXT)],
+        [
+            "docker",
+            "build",
+            "--build-arg",
+            f"VERSION={TEST_VERSION}",
+            "-t",
+            db_image_tag,
+            str(BUILD_CONTEXT),
+        ],
         capture_output=True,
         text=True,
     )
@@ -169,22 +182,19 @@ def test_built_dockerfile(built_db_image: BuiltImage):
 @pytest.mark.slow
 @pytest.mark.integration
 def test_container_version_matches_project(built_db_image: BuiltImage):
-    """Test that the version output from the container matches the project version."""
+    """Test that the version baked into the image matches the TEST_VERSION build-arg.
+
+    This validates the full chain:
+      --build-arg VERSION=<ver>  →  SETUPTOOLS_SCM_PRETEND_VERSION  →  installed package
+    The entry-point is invoked directly from the venv (no `uv run` overhead)
+    because the runtime image does not have a project context for uv to resolve.
+    """
     if not built_db_image.ok:
         pytest.skip("Docker build failed; skipping version test")
 
-    # Run the container and execute the version command
+    # kivoll-scrape is on PATH via /app/.venv/bin (set in the Dockerfile).
     result = subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            built_db_image.tag,
-            "uv",
-            "run",
-            "kivoll-scrape",
-            "--version",
-        ],
+        ["docker", "run", "--rm", built_db_image.tag, "kivoll-scrape", "--version"],
         capture_output=True,
         text=True,
         timeout=30,
@@ -194,11 +204,10 @@ def test_container_version_matches_project(built_db_image: BuiltImage):
         f"Failed to get version from container: {result.stderr}"
     )
 
-    # Extract version from command output (typically "kivoll_worker <version>")
+    # Output is typically "kivoll_worker <version>"
     container_version = result.stdout.strip().split()[-1]
 
-    # Compare with project version
-    assert container_version == __version__, (
+    assert container_version == TEST_VERSION, (
         f"Container version '{container_version}' "
-        f"does not match project version '{__version__}'"
+        f"does not match expected build version '{TEST_VERSION}'"
     )

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -179,9 +179,50 @@ def test_built_dockerfile(built_db_image: BuiltImage):
     assert built_db_image.stdout or built_db_image.stderr, "docker build output missing"
 
 
+@pytest.fixture(scope="session")
+def container_package_installed(built_db_image: BuiltImage) -> bool:
+    """Return True if kivoll_worker is importable inside the built image.
+
+    Skips automatically if the image build itself failed.
+    """
+    if not built_db_image.ok:
+        pytest.skip("Docker build failed; skipping package installation check")
+
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            built_db_image.tag,
+            "python",
+            "-c",
+            "import kivoll_worker",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.returncode == 0
+
+
 @pytest.mark.slow
 @pytest.mark.integration
-def test_container_version_matches_project(built_db_image: BuiltImage):
+def test_container_package_installed(
+    built_db_image: BuiltImage, container_package_installed: bool
+):
+    """Test that the kivoll_worker package is importable inside the container."""
+    assert container_package_installed, (
+        "kivoll_worker is not importable in the container — "
+        "the wheel may not have been installed correctly.\n"
+        f"Build stderr: {built_db_image.stderr}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_container_version_matches_project(
+    built_db_image: BuiltImage, container_package_installed: bool
+):
     """Test that the version baked into the image matches the TEST_VERSION build-arg.
 
     This validates the full chain:
@@ -191,6 +232,8 @@ def test_container_version_matches_project(built_db_image: BuiltImage):
     """
     if not built_db_image.ok:
         pytest.skip("Docker build failed; skipping version test")
+    if not container_package_installed:
+        pytest.skip("Package not importable; skipping version test")
 
     # kivoll-scrape is on PATH via /app/.venv/bin (set in the Dockerfile).
     result = subprocess.run(


### PR DESCRIPTION
- Enable deterministic versioning by passing `VERSION` build-arg and setting `SETUPTOOLS_SCM_PRETEND_VERSION`  
- Update CI workflows and Dockerfile for reproducible builds and test coverage